### PR TITLE
Run ImPlot CMake consumer test

### DIFF
--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -8,3 +8,6 @@ if errorlevel 1 exit 1
 
 cmake --build tests/build --parallel --config Release
 if errorlevel 1 exit 1
+
+ctest --test-dir tests/build --output-on-failure -C Release
+if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -10,3 +10,4 @@ cmake tests \
     -DCMAKE_BUILD_TYPE=Release
 
 cmake --build tests/build --parallel
+ctest --test-dir tests/build --output-on-failure

--- a/recipe/tests/CMakeLists.txt
+++ b/recipe/tests/CMakeLists.txt
@@ -11,3 +11,6 @@ find_package(implot CONFIG REQUIRED)
 
 add_executable(implot_test main.cpp)
 target_link_libraries(implot_test PRIVATE imgui::imgui implot::implot)
+
+enable_testing()
+add_test(NAME implot_test COMMAND implot_test)


### PR DESCRIPTION
## Summary
- run the existing downstream `find_package(imgui/implot)` CMake consumer executable via CTest
- keep the change test-only with no recipe metadata or generated-file changes

## Validation
- `git diff --check upstream/main..HEAD`
- `conda-smithy recipe-lint --conda-forge recipe`
- `conda-smithy rerender -c auto` (no changes)

Local package build was not run because this host has no `conda`, `mamba`, or `micromamba` executable on `PATH`; CI should cover the platform matrix.
